### PR TITLE
Add web client configuration and execution controls

### DIFF
--- a/app/api/config/[target]/route.ts
+++ b/app/api/config/[target]/route.ts
@@ -17,6 +17,22 @@ const CONFIG_TARGETS = {
     configDir: path.join(appRoot, "simulation-bridge", "matlab-agent"),
     fileName: "config.yaml",
   },
+  "client-rabbitmq": {
+    configDir: path.join(appRoot, "client", "rabbitmq"),
+    fileName: "rabbitmq_use.yaml",
+  },
+  "client-mqtt": {
+    configDir: path.join(appRoot, "client", "mqtt"),
+    fileName: "mqtt_use.yaml",
+  },
+  "client-rest": {
+    configDir: path.join(appRoot, "client", "rest"),
+    fileName: "rest_use.yaml",
+  },
+  "client-simulation": {
+    configDir: path.join(appRoot, "client"),
+    fileName: "simulation.yaml",
+  },
 } as const;
 
 type TargetKey = keyof typeof CONFIG_TARGETS;

--- a/app/api/runtime/[target]/route.ts
+++ b/app/api/runtime/[target]/route.ts
@@ -21,8 +21,38 @@ type RouteContext = {
 
 const appRoot = process.cwd();
 const projectRoot = appRoot;
+const clientRoot = path.join(appRoot, "client");
 
-const RUNTIMES: Record<RuntimeId, RuntimeDefinition> = {
+const CLIENT_PROTOCOLS: Record<
+  Extract<RuntimeId, `client-${string}`>,
+  {
+    directory: string;
+    script: string;
+    configFile: string;
+  }
+> = {
+  "client-rabbitmq": {
+    directory: path.join(clientRoot, "rabbitmq"),
+    script: "rabbitmq_client.py",
+    configFile: "rabbitmq_use.yaml",
+  },
+  "client-mqtt": {
+    directory: path.join(clientRoot, "mqtt"),
+    script: "mqtt_client.py",
+    configFile: "mqtt_use.yaml",
+  },
+  "client-rest": {
+    directory: path.join(clientRoot, "rest"),
+    script: "rest_client.py",
+    configFile: "rest_use.yaml",
+  },
+};
+
+const CLIENT_RUNTIME_IDS = Object.keys(CLIENT_PROTOCOLS) as Array<
+  Extract<RuntimeId, `client-${string}`>
+>;
+
+const baseRuntimes: Record<string, RuntimeDefinition> = {
   "simulation-bridge": {
     packageName: "simulation-bridge",
     wheelPath: path.join(projectRoot, "dist", "simulation_bridge-0.1.1-py3-none-any.whl"),
@@ -51,6 +81,26 @@ const RUNTIMES: Record<RuntimeId, RuntimeDefinition> = {
     }),
   },
 };
+
+CLIENT_RUNTIME_IDS.forEach((id) => {
+  const info = CLIENT_PROTOCOLS[id];
+  const workingDirectory = info.directory;
+  const requirementsPath = path.join(workingDirectory, "requirements.txt");
+  baseRuntimes[id] = {
+    requirementsPath,
+    workingDirectory,
+    configPath: path.join(workingDirectory, info.configFile),
+    spawnCommand: () => ({
+      command: "bash",
+      args: [
+        "-lc",
+        ["source venv/bin/activate", `python3 ${info.script}`].join(" && "),
+      ],
+    }),
+  };
+});
+
+const RUNTIMES = baseRuntimes as Record<RuntimeId, RuntimeDefinition>;
 
 const getRuntime = (target: string) => {
   return RUNTIMES[target as RuntimeId] ?? null;
@@ -92,8 +142,25 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
     return NextResponse.json({ error: `Target non supportato: ${target}` }, { status: 404 });
   }
 
-  const result = await runCommand("pip", ["show", runtime.packageName]);
-  const installed = result.exitCode === 0;
+  let installed = false;
+  let infoOutput = "";
+
+  if (runtime.packageName) {
+    const result = await runCommand("pip", ["show", runtime.packageName]);
+    installed = result.exitCode === 0;
+    infoOutput = result.stdout || result.stderr;
+  } else if (runtime.requirementsPath && runtime.workingDirectory) {
+    const pythonPath = path.join(runtime.workingDirectory, "venv", "bin", "python");
+    try {
+      await fs.access(pythonPath);
+      installed = true;
+      infoOutput = `Virtual environment detected at ${path.dirname(pythonPath)}`;
+    } catch (_error) {
+      installed = false;
+      infoOutput = "Virtual environment not initialized.";
+    }
+  }
+
   runtimeManager.setInstalledFlag(target as RuntimeId, installed);
 
   let configExists = false;
@@ -108,7 +175,7 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
 
   return NextResponse.json({
     installed,
-    output: result.stdout || result.stderr,
+    output: infoOutput,
     configPath: runtime.configPath,
     configExists,
     running: snapshot.running,
@@ -132,19 +199,66 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
   }
 
   if (action === "init") {
-    const installResult = await runCommand("pip", ["install", runtime.wheelPath]);
-    const success = installResult.exitCode === 0;
-    if (success) {
-      runtimeManager.setInstalledFlag(target as RuntimeId, true);
+    if (runtime.wheelPath && runtime.packageName) {
+      const installResult = await runCommand("pip", ["install", runtime.wheelPath]);
+      const success = installResult.exitCode === 0;
+      if (success) {
+        runtimeManager.setInstalledFlag(target as RuntimeId, true);
+      }
+
+      return NextResponse.json({
+        success,
+        installed: success,
+        stdout: installResult.stdout,
+        stderr: installResult.stderr,
+        exitCode: installResult.exitCode,
+      });
     }
 
-    return NextResponse.json({
-      success,
-      installed: success,
-      stdout: installResult.stdout,
-      stderr: installResult.stderr,
-      exitCode: installResult.exitCode,
-    });
+    if (runtime.requirementsPath && runtime.workingDirectory) {
+      const createVenv = await runCommand(
+        "python3",
+        ["-m", "venv", "venv"],
+        runtime.workingDirectory
+      );
+      if (createVenv.exitCode !== 0) {
+        return NextResponse.json(
+          {
+            success: false,
+            installed: false,
+            stdout: createVenv.stdout,
+            stderr: createVenv.stderr,
+            exitCode: createVenv.exitCode,
+          },
+          { status: 500 }
+        );
+      }
+
+      const pipPath = path.join(runtime.workingDirectory, "venv", "bin", "pip");
+      const installDeps = await runCommand(
+        pipPath,
+        ["install", "-r", runtime.requirementsPath],
+        runtime.workingDirectory
+      );
+
+      const success = installDeps.exitCode === 0;
+      if (success) {
+        runtimeManager.setInstalledFlag(target as RuntimeId, true);
+      }
+
+      return NextResponse.json({
+        success,
+        installed: success,
+        stdout: [createVenv.stdout, installDeps.stdout].filter(Boolean).join("\n"),
+        stderr: [createVenv.stderr, installDeps.stderr].filter(Boolean).join("\n"),
+        exitCode: installDeps.exitCode,
+      });
+    }
+
+    return NextResponse.json(
+      { error: "Routine di inizializzazione non disponibile per il target selezionato." },
+      { status: 400 }
+    );
   }
 
   if (action === "run") {
@@ -155,6 +269,24 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
         { error: "Config non trovato. Salva prima la configurazione dalla home." },
         { status: 400 }
       );
+    }
+
+    if (CLIENT_RUNTIME_IDS.includes(target as RuntimeId)) {
+      const otherClientsRunning = CLIENT_RUNTIME_IDS.some((id) => {
+        if (id === target) return false;
+        const snapshot = runtimeManager.getSnapshot(id);
+        return snapshot.running;
+      });
+
+      if (otherClientsRunning) {
+        return NextResponse.json(
+          {
+            error:
+              "Un altro client è già in esecuzione. Arrestalo prima di avviarne uno nuovo.",
+          },
+          { status: 409 }
+        );
+      }
     }
 
     const result = runtimeManager.startRuntime(target as RuntimeId, runtime, projectRoot);

--- a/app/api/runtime/_manager.ts
+++ b/app/api/runtime/_manager.ts
@@ -4,8 +4,10 @@ import type { ChildProcessWithoutNullStreams } from "child_process";
 import type { RuntimeId } from "@/lib/runtimes";
 
 export interface RuntimeDefinition {
-  packageName: string;
-  wheelPath: string;
+  packageName?: string;
+  wheelPath?: string;
+  requirementsPath?: string;
+  workingDirectory?: string;
   configPath: string;
   spawnCommand: (configPath: string) => { command: string; args: string[] };
 }
@@ -135,10 +137,11 @@ class RuntimeManager {
     }
 
     const { command, args } = runtime.spawnCommand(runtime.configPath);
+    const workingDirectory = runtime.workingDirectory ?? cwd;
 
     try {
       const child = spawn(command, args, {
-        cwd,
+        cwd: workingDirectory,
         env: process.env,
         shell: true
       });

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Cog, Cpu, PlayCircle, Settings2 } from "lucide-react";
+import { Cog, Cpu, PlayCircle, Settings2, Share2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -14,6 +14,11 @@ const navigation = [
         label: "Simulation Bridge",
         href: "/config/simulation-bridge",
         icon: Cog,
+      },
+      {
+        label: "Client",
+        href: "/config/client",
+        icon: Share2,
       },
       {
         label: "AnyLogic",

--- a/app/config/client/page.tsx
+++ b/app/config/client/page.tsx
@@ -1,0 +1,480 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/app/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/app/components/ui/card";
+import { Label } from "@/app/components/ui/label";
+import { Select } from "@/app/components/ui/select";
+import { Textarea } from "@/app/components/ui/textarea";
+
+type ProtocolKey = "rabbitmq" | "mqtt" | "rest";
+
+type ProtocolDefinition = {
+  label: string;
+  target: string;
+  defaultConfig: string;
+  description: string;
+  fileName: string;
+};
+
+const protocolDefinitions: Record<ProtocolKey, ProtocolDefinition> = {
+  rabbitmq: {
+    label: "RabbitMQ",
+    target: "client-rabbitmq",
+    description:
+      "Configure the AMQP connection, exchanges and queues used by the Digital Twin client.",
+    fileName: "rabbitmq_use.yaml",
+    defaultConfig: `rabbitmq:
+  host: localhost
+  port: 5672
+  vhost: /
+  username: guest
+  password: guest
+  tls: false
+
+exchanges:
+  input_bridge:
+    name: "ex.input.bridge"
+    type: "topic"
+    durable: true
+
+  bridge_result:
+    name: "ex.bridge.result"
+    type: "topic"
+    durable: true
+
+queue:
+  result_queue_prefix: "Q"
+  durable: true
+  routing_key: "*.result"
+
+digital_twin:
+  dt_id: "dt"
+  routing_key_send: "dt"
+
+payload_file: "../simulation.yaml"
+`,
+  },
+  mqtt: {
+    label: "MQTT",
+    target: "client-mqtt",
+    description:
+      "Define the broker connection details together with the topics used for input and output streams.",
+    fileName: "mqtt_use.yaml",
+    defaultConfig: `mqtt:
+  host: "localhost"
+  port: 1883
+  keepalive: 60
+  qos: 0
+  input_topic: "bridge/input"
+  output_topic: "bridge/output"
+  username: "guest"
+  password: "guest"
+  tls: false
+
+payload_file: "../simulation.yaml"
+`,
+  },
+  rest: {
+    label: "REST",
+    target: "client-rest",
+    description:
+      "Set the HTTPS endpoint, JWT credentials and TLS verification strategy for REST executions.",
+    fileName: "rest_use.yaml",
+    defaultConfig: `# REST client configuration
+#
+# 1. URL
+#    • Use "https://" for a TLS connection.
+#    • Use "http://" if you want to completely disable TLS
+#      (the server must obviously also expose HTTP).
+#
+# 2. ssl_verify
+#    This field controls **certificate verification** on the client side.
+#
+#      false  ──► TLS without any verification (DO NOT use in production)
+#      true   ──► Verification with the operating system's trust store
+#                (works only with certificates signed by public CAs
+#                 or internal CAs already installed in the system).
+#      <path> ──► Verification enabled and, additionally, considers trusted
+#                the specified PEM certificate/CA (useful for self-signed).
+
+
+# URL endpoint to send the request to
+url: "https://127.0.0.1:5000/message"   # change to http://... to disable TLS
+
+# Path to the YAML file you want to send as payload
+yaml_file: "../simulation.yaml"
+
+# JWT configuration
+secret: "your-very-secure-and-long-secret-key-that-is-at-least-32-characters"
+issuer: "simulation-bridge"   # Issuer of the JWT token
+subject: "client-123"         # Subject of the JWT token
+
+# Optional values
+ttl: 900        # Token time-to-live in seconds (default 15 min)
+timeout: 600    # Request timeout in seconds
+
+# TLS verification strategy (see explanation above)
+ssl_verify: false
+`,
+  },
+};
+
+const defaultSimulationYaml = `simulation:
+  request_id: abcdef12345
+  client_id: dt
+  simulator: matlab
+  type: streaming
+  file: SimulationStreaming.m
+  timestamp: "2024-01-01T00:00:00Z" # Timestamp for the simulation request in ISO 8601 format
+  timeout: 60 # Timeout for the simulation in seconds
+  inputs:
+    time_step: 0.05 # Time step for the simulation
+    num_agents: 8 # Number of agents
+    max_steps: 200 # Max steps for the simulation
+    avoidance_threshold: 1 # Minimum distance to avoid collision
+    show_agent_index: 1 # Index of the agent to show
+    use_gui: true # GUI flag
+  outputs:
+    time: float # execution time
+    current_step: int # current step of the simulation
+    positions: "[[float, float]]" # positions of the agents
+    velocities: "[[float, float]]" # velocities of the agents
+    running: bool # running flag
+`;
+
+export default function ClientConfigPage() {
+  const [selectedProtocol, setSelectedProtocol] = useState<ProtocolKey>("rabbitmq");
+  const [configYaml, setConfigYaml] = useState(protocolDefinitions.rabbitmq.defaultConfig);
+  const [configPath, setConfigPath] = useState("");
+  const [configSaving, setConfigSaving] = useState(false);
+  const [configMessage, setConfigMessage] = useState("");
+  const [configError, setConfigError] = useState("");
+  const [configCopied, setConfigCopied] = useState(false);
+
+  const [simulationYaml, setSimulationYaml] = useState(defaultSimulationYaml);
+  const [simulationPath, setSimulationPath] = useState("");
+  const [simulationSaving, setSimulationSaving] = useState(false);
+  const [simulationMessage, setSimulationMessage] = useState("");
+  const [simulationError, setSimulationError] = useState("");
+  const [simulationCopied, setSimulationCopied] = useState(false);
+
+  const protocolInfo = useMemo(() => protocolDefinitions[selectedProtocol], [selectedProtocol]);
+
+  useEffect(() => {
+    let ignore = false;
+
+    const loadConfig = async () => {
+      try {
+        const response = await fetch(`/api/config/${protocolInfo.target}`);
+        if (!response.ok) {
+          return;
+        }
+
+        const data = await response.json();
+        if (ignore) return;
+
+        if (data.exists && typeof data.content === "string") {
+          setConfigYaml(data.content);
+        } else {
+          setConfigYaml(protocolInfo.defaultConfig);
+        }
+        setConfigPath(typeof data.path === "string" ? data.path : "");
+      } catch (error) {
+        console.error("Unable to load client configuration", error);
+        if (!ignore) {
+          setConfigYaml(protocolInfo.defaultConfig);
+          setConfigPath("");
+        }
+      }
+    };
+
+    loadConfig();
+
+    return () => {
+      ignore = true;
+    };
+  }, [protocolInfo]);
+
+  useEffect(() => {
+    let ignore = false;
+
+    const loadSimulationYaml = async () => {
+      try {
+        const response = await fetch("/api/config/client-simulation");
+        if (!response.ok) return;
+        const data = await response.json();
+        if (ignore) return;
+        if (data.exists && typeof data.content === "string") {
+          setSimulationYaml(data.content);
+        }
+        setSimulationPath(typeof data.path === "string" ? data.path : "");
+      } catch (error) {
+        console.error("Unable to load simulation payload", error);
+      }
+    };
+
+    loadSimulationYaml();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  const handleProtocolChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value as ProtocolKey;
+    setSelectedProtocol(value);
+    setConfigMessage("");
+    setConfigError("");
+    setConfigCopied(false);
+    setConfigPath("");
+  };
+
+  const handleConfigSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setConfigSaving(true);
+    setConfigMessage("");
+    setConfigError("");
+
+    try {
+      const response = await fetch(`/api/config/${protocolInfo.target}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ yaml: configYaml }),
+      });
+
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setConfigError(data.error ?? "Error saving configuration.");
+        return;
+      }
+
+      const savedPath = typeof data.path === "string" ? data.path : "";
+      setConfigPath(savedPath);
+      setConfigMessage(
+        savedPath ? `Configuration saved to ${savedPath}` : "Configuration saved."
+      );
+      setTimeout(() => setConfigMessage(""), 5000);
+    } catch (error) {
+      console.error("Error saving client configuration", error);
+      setConfigError("Network error while saving configuration.");
+    } finally {
+      setConfigSaving(false);
+    }
+  };
+
+  const handleConfigCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(configYaml);
+      setConfigCopied(true);
+      setTimeout(() => setConfigCopied(false), 2000);
+    } catch (error) {
+      console.error("Unable to copy YAML", error);
+    }
+  };
+
+  const handleConfigReset = () => {
+    setConfigYaml(protocolInfo.defaultConfig);
+    setConfigMessage("Values restored to default.");
+    setTimeout(() => setConfigMessage(""), 3000);
+  };
+
+  const handleSimulationSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSimulationSaving(true);
+    setSimulationMessage("");
+    setSimulationError("");
+
+    try {
+      const response = await fetch("/api/config/client-simulation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ yaml: simulationYaml }),
+      });
+
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setSimulationError(data.error ?? "Error saving simulation payload.");
+        return;
+      }
+
+      const savedPath = typeof data.path === "string" ? data.path : "";
+      setSimulationPath(savedPath);
+      setSimulationMessage(
+        savedPath
+          ? `Simulation payload saved to ${savedPath}`
+          : "Simulation payload saved."
+      );
+      setTimeout(() => setSimulationMessage(""), 5000);
+    } catch (error) {
+      console.error("Error saving simulation payload", error);
+      setSimulationError("Network error while saving simulation payload.");
+    } finally {
+      setSimulationSaving(false);
+    }
+  };
+
+  const handleSimulationCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(simulationYaml);
+      setSimulationCopied(true);
+      setTimeout(() => setSimulationCopied(false), 2000);
+    } catch (error) {
+      console.error("Unable to copy simulation payload", error);
+    }
+  };
+
+  const handleSimulationReset = () => {
+    setSimulationYaml(defaultSimulationYaml);
+    setSimulationMessage("Values restored to default.");
+    setTimeout(() => setSimulationMessage(""), 3000);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold">Client configuration</h1>
+        <p className="text-sm text-zinc-500">
+          Choose a protocol, adjust its configuration file and manage the shared
+          <code className="mx-1">simulation.yaml</code> payload.
+        </p>
+      </div>
+
+      <form onSubmit={handleConfigSubmit} className="grid gap-6">
+        <Card>
+          <CardHeader className="space-y-4">
+            <div className="flex flex-col gap-1">
+              <CardTitle>Protocol configuration</CardTitle>
+              <CardDescription>{protocolInfo.description}</CardDescription>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="client-protocol">Protocol</Label>
+              <Select
+                id="client-protocol"
+                value={selectedProtocol}
+                onChange={handleProtocolChange}
+              >
+                {Object.entries(protocolDefinitions).map(([key, value]) => (
+                  <option key={key} value={key}>
+                    {value.label}
+                  </option>
+                ))}
+              </Select>
+              <p className="text-xs text-zinc-500">
+                Editing {protocolInfo.label} will save changes to
+                {" "}
+                {configPath ? (
+                  <code>{configPath}</code>
+                ) : (
+                  <code>{protocolInfo.fileName}</code>
+                )}
+              </p>
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            {configMessage ? (
+              <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+                {configMessage}
+              </div>
+            ) : null}
+            {configError ? (
+              <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-600">
+                {configError}
+              </div>
+            ) : null}
+
+            <div className="grid gap-2">
+              <Label htmlFor="client-config">Configuration file</Label>
+              <Textarea
+                id="client-config"
+                value={configYaml}
+                onChange={(event) => setConfigYaml(event.target.value)}
+                className="min-h-[400px] font-mono text-xs"
+              />
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Button type="submit" disabled={configSaving}>
+                {configSaving ? "Saving..." : "Save configuration"}
+              </Button>
+              <Button type="button" variant="outline" onClick={handleConfigReset}>
+                Reset to default
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleConfigCopy}
+              >
+                {configCopied ? "Copied" : "Copy YAML"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </form>
+
+      <form onSubmit={handleSimulationSubmit} className="grid gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Simulation payload</CardTitle>
+            <CardDescription>
+              This file is shared across every client and will be sent as the
+              request payload.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            {simulationMessage ? (
+              <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+                {simulationMessage}
+              </div>
+            ) : null}
+            {simulationError ? (
+              <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-600">
+                {simulationError}
+              </div>
+            ) : null}
+
+            <div className="flex flex-col gap-1 text-sm text-zinc-500">
+              <span>
+                <strong>Path:</strong>{" "}
+                {simulationPath ? <code>{simulationPath}</code> : "File not saved yet"}
+              </span>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="client-simulation">simulation.yaml</Label>
+              <Textarea
+                id="client-simulation"
+                value={simulationYaml}
+                onChange={(event) => setSimulationYaml(event.target.value)}
+                className="min-h-[400px] font-mono text-xs"
+              />
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Button type="submit" disabled={simulationSaving}>
+                {simulationSaving ? "Saving..." : "Save simulation"}
+              </Button>
+              <Button type="button" variant="outline" onClick={handleSimulationReset}>
+                Reset to default
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleSimulationCopy}
+              >
+                {simulationCopied ? "Copied" : "Copy YAML"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </form>
+    </div>
+  );
+}

--- a/app/execution/page.tsx
+++ b/app/execution/page.tsx
@@ -61,6 +61,12 @@ const joinOutputs = (stdout?: string, stderr?: string) =>
     .join("\n\n");
 
 export default function ExecutionPage() {
+  const clientRuntimeIds: RuntimeId[] = [
+    "client-rabbitmq",
+    "client-mqtt",
+    "client-rest",
+  ];
+
   const initialState = runtimeOrder.reduce<Record<RuntimeId, RuntimeUIState>>(
     (acc, id) => {
       acc[id] = {
@@ -397,16 +403,21 @@ export default function ExecutionPage() {
         </p>
       </div>
 
-      <div className="grid gap-6 grid-cols-1 lg:grid-cols-2">
-        {/* Left column (50%) */}
+      <div className="grid gap-6 grid-cols-1 xl:grid-cols-3">
+        {/* Simulation Bridge */}
         <div className="grid gap-4">
           {renderRuntimeCard("simulation-bridge")}
         </div>
 
-        {/* Right column (50%) */}
+        {/* Agents */}
         <div className="grid gap-4">
           {renderRuntimeCard("anylogic-agent")}
           {renderRuntimeCard("matlab-agent")}
+        </div>
+
+        {/* Clients */}
+        <div className="grid gap-4">
+          {clientRuntimeIds.map((id) => renderRuntimeCard(id))}
         </div>
       </div>
 
@@ -414,8 +425,12 @@ export default function ExecutionPage() {
         Need to edit configurations? Go to{" "}
         <Link className="underline" href="/config/simulation-bridge">
           Configuration
-        </Link>
-        .
+        </Link>{" "}
+        or update the client files from the{" "}
+        <Link className="underline" href="/config/client">
+          Client configuration
+        </Link>{" "}
+        area.
       </div>
     </div>
   );

--- a/lib/runtimes.ts
+++ b/lib/runtimes.ts
@@ -1,9 +1,18 @@
-export type RuntimeId = "simulation-bridge" | "anylogic-agent" | "matlab-agent";
+export type RuntimeId =
+  | "simulation-bridge"
+  | "anylogic-agent"
+  | "matlab-agent"
+  | "client-rabbitmq"
+  | "client-mqtt"
+  | "client-rest";
 
 export const runtimeOrder: RuntimeId[] = [
   "simulation-bridge",
   "anylogic-agent",
   "matlab-agent",
+  "client-rabbitmq",
+  "client-mqtt",
+  "client-rest",
 ];
 
 export interface RuntimeUiDefinition {
@@ -34,5 +43,29 @@ export const runtimeUiDefinitions: Record<RuntimeId, RuntimeUiDefinition> = {
       "Execute Matlab scenarios and communicate with the bridge following the settings defined in the configuration file.",
     installHint: "pip install dist/matlab_agent-1.0.0-py3-none-any.whl",
     runPreview: "matlab-agent --config-file <config.yaml>",
+  },
+  "client-rabbitmq": {
+    title: "RabbitMQ Client",
+    description:
+      "Send simulation payloads through RabbitMQ and listen for bridge responses using the dedicated Digital Twin queue.",
+    installHint:
+      "python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt",
+    runPreview: "python3 rabbitmq_client.py",
+  },
+  "client-mqtt": {
+    title: "MQTT Client",
+    description:
+      "Publish simulation requests to the MQTT input topic and stream results from the configured output topic.",
+    installHint:
+      "python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt",
+    runPreview: "python3 mqtt_client.py",
+  },
+  "client-rest": {
+    title: "REST Client",
+    description:
+      "Send HTTPS requests with JWT authentication to the Simulation Bridge REST endpoint and inspect the responses.",
+    installHint:
+      "python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt",
+    runPreview: "python3 rest_client.py",
   },
 };


### PR DESCRIPTION
## Summary
- add a dedicated /config/client route so users can edit each protocol YAML and the shared simulation payload from the UI
- extend runtime definitions to prepare per-client virtual environments and run the selected client in the background with mutual exclusion
- surface the new clients in the execution dashboard with a third column and update navigation to expose the client tools

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68df0426b13c8333b481cf228a6d5ac4